### PR TITLE
Fix async completion error on image task

### DIFF
--- a/STARTERKIT/tasks/images.js
+++ b/STARTERKIT/tasks/images.js
@@ -13,9 +13,9 @@ const config = [
   }),
   imagemin.svgo({
     plugins: [
-      { removeViewBox: true },
-      { cleanupIDs: true },
-      { cleanupAttrs: true },
+      {removeViewBox:true},
+      {cleanupIDs:true},
+      {cleanupAttrs:true},
     ]
   })
 ];

--- a/STARTERKIT/tasks/images.js
+++ b/STARTERKIT/tasks/images.js
@@ -13,15 +13,15 @@ const config = [
   }),
   imagemin.svgo({
     plugins: [
-      {removeViewBox: true},
-      {cleanupIDs:true},
-      {cleanupAttrs: true},
+      { removeViewBox: true },
+      { cleanupIDs: true },
+      { cleanupAttrs: true },
     ]
   })
 ];
 
 const compress = function () {
-  gulp.src('./assets/src/images/**/*')
+  return gulp.src('./assets/src/images/**/*')
     .pipe(imagemin(config))
     .pipe(gulp.dest('./assets/dist'));
 };

--- a/STARTERKIT/tasks/images.js
+++ b/STARTERKIT/tasks/images.js
@@ -13,9 +13,9 @@ const config = [
   }),
   imagemin.svgo({
     plugins: [
-      {removeViewBox:true},
+      {removeViewBox: true},
       {cleanupIDs:true},
-      {cleanupAttrs:true},
+      {cleanupAttrs: true},
     ]
   })
 ];


### PR DESCRIPTION
Before:

> deck-starterkit@1.0.0 gulp /Users/becky/Sites/deck/STARTERKIT
> gulp "images"

[10:29:38] Using gulpfile ~/Sites/deck/STARTERKIT/gulpfile.js
[10:29:38] Starting 'images'...
[10:29:38] gulp-imagemin: Minified 2 images (saved 419 B - 26%)
[10:29:38] The following tasks did not complete: images
[10:29:38] Did you forget to signal async completion?

After:

> deck-starterkit@1.0.0 start /Users/becky/Sites/deck/STARTERKIT
> gulp "images"

[10:46:49] Using gulpfile ~/Sites/deck/STARTERKIT/gulpfile.js
[10:46:49] Starting 'images'...
[10:46:49] gulp-imagemin: Minified 0 images
[10:46:49] Finished 'images' after 37 ms