### PR TITLE
add typescript as an explicit dependency

### DIFF
--- a/STARTERKIT/package.json
+++ b/STARTERKIT/package.json
@@ -26,6 +26,7 @@
     "stylelint": "^8.4.0",
     "stylelint-formatter-pretty": "^1.0.3",
     "ts-loader": "^3.3.1",
+    "typescript": "^2.7.1",
     "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^3.10.0"
   },


### PR DESCRIPTION
because not everyone might have typescript installed globally, also would cause less issues with people having different versions of typescript installed (?)