### PR TITLE
Add gulp default task and npm start script script

### DIFF
--- a/STARTERKIT/gulpfile.js
+++ b/STARTERKIT/gulpfile.js
@@ -1,8 +1,8 @@
-const gulp = require('gulp');
-const styles = require('./tasks/styles');
-const fonts = require('./tasks/fonts');
-const images = require('./tasks/images');
-const scripts = require('./tasks/scripts');
+const gulp = require("gulp");
+const styles = require("./tasks/styles");
+const fonts = require("./tasks/fonts");
+const images = require("./tasks/images");
+const scripts = require("./tasks/scripts");
 
 gulp.task(styles.compile);
 gulp.task(styles.lint);
@@ -14,3 +14,10 @@ gulp.task(scripts.build);
 
 gulp.task(fonts);
 gulp.task(images);
+
+gulp.task(
+  "default",
+  gulp.parallel("styles", "scripts", "fonts", "images", function(done) {
+    done();
+  })
+);

--- a/STARTERKIT/package.json
+++ b/STARTERKIT/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Tools for your Deck subtheme.",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "gulp"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
* much easier/quicker to just run gulp to compile the files, more tasks can be added by user as necessary, but also provides a boilerplate for a task if users are not familiar with Gulp 4
* npm scripts would prevent users needing to install gulp globally on their system (no clashing with other projects gulp versions this way..)